### PR TITLE
Fix resume_job API path

### DIFF
--- a/printerInterface.py
+++ b/printerInterface.py
@@ -465,7 +465,7 @@ class PrinterData:
 
 	def resume_job(self): #fixed
 		print('Resuming job:')
-		self.postREST('printer/print/resume', json=None)
+		self.postREST('/printer/print/resume', json=None)
 
 	def set_feedrate(self, fr):
 		self.feedrate_percentage = fr


### PR DESCRIPTION
## Summary
- correct API path for `resume_job` in `printerInterface.py`

## Testing
- `python3 -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_688d54e7f7488330ac815ab3dc8b7373